### PR TITLE
fix output length and make params usable outside this lib

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ extern "C" {
 }
 
 ///The Scrypt parameter values
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct ScryptParams {
     /// Number of iterations
     pub n: u64,


### PR DESCRIPTION
Previously the output length was hardcoded to be 32 bytes, which could overflow the provided byte slice. Also `ScryptParams` fields are made all-public to make it more usable in the outside code (e.g. for serialization/deserialization).